### PR TITLE
change selector that contains application context

### DIFF
--- a/application-review.user.js
+++ b/application-review.user.js
@@ -268,7 +268,7 @@ async function reject({
     note = null,
     startNewProcessAfterRejection = false,
 }) {
-    const mainEl = document.querySelector("*[data-react-props]");
+    const mainEl = document.querySelector("#app_review_wrapper [data-react-props]")
     if (!mainEl)
         throw new Error("[Canonical GH] Failed to get the application context");
     const context = JSON.parse(mainEl.getAttribute("data-react-props"));


### PR DESCRIPTION
## Done

Use a more specific selector to get the element containing the application context. (Probably GH updated their UI and caused this to break)

## QA
- Install Tampermonkey and `[application-review.user.js](https://github.com/canonical/greenhouse-browser-scripts/blob/main/application-review.user.js)`, if you haven't (instructions in README) 
- Go to "review applications" mode in a [demo job](https://canonical.greenhouse.io/applications/review/app_review?hiring_plan_id=2044596&interview_stage_id=15296239)
- Try to reject some candidate(s) with the quick rejection buttons and see if it works

## Issue
Fixes #15 