### PR TITLE
Add waited recovery for slow UIs

### DIFF
--- a/application-review.user.js
+++ b/application-review.user.js
@@ -62,6 +62,11 @@
             }
         });
 
+        const waitRecover = setTimeout(() => {
+            rejectModal.classList.remove("hide-modal");
+            setEnabled();
+        }, 5000);
+
         MutationObserver =
             window.MutationObserver || window.WebKitMutationObserver;
         var observer = new MutationObserver(function (mutations) {
@@ -71,6 +76,7 @@
                     "Subject"
                 ) {
                     rejectButton.click();
+                    clearTimeout(waitRecover);
                     setEnabled();
                     setTimeout(
                         () => rejectModal.classList.remove("hide-modal"),

--- a/application-review.user.js
+++ b/application-review.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Greenhouse Application Review
 // @namespace    https://canonical.com/
-// @version      1.0.0
+// @version      1.0.1
 // @author       Canonical's workplace engineering team
 // @description  Add shortcut buttons to application review page
 // @homepage     https://github.com/canonical/greenhouse-browser-scripts


### PR DESCRIPTION
## Done

- After 5 seconds of no Mutations found the Modal is revealed and everything is reset for manual recovery

## QA

- Drop it over the currently installed script in the Tamper monkey dashboard.