### PR TITLE
Add new URL match rule for written-interview-in-new-tab.user.js

### DIFF
--- a/written-interview-in-new-tab.user.js
+++ b/written-interview-in-new-tab.user.js
@@ -12,6 +12,7 @@
 // @supportURL   https://github.com/canonical/greenhouse-browser-scripts/issues
 
 // @match        https://canonical.greenhouse.io/guides/**/people/**
+// @match        https://canonical.greenhouse.io/scorecards/**
 // ==/UserScript==
 
 const downloadLinks = [


### PR DESCRIPTION
The URL where I review written interviews and download the PDFs matches `https://canonical.greenhouse.io/scorecards/**`, and not the current one (`https://canonical.greenhouse.io/guides/**/people/**`). I've added the new one.