### PR TITLE
WD-3819 Replace ariaLabel with getAttribute("aria-label")

### DIFF
--- a/application-review.user.js
+++ b/application-review.user.js
@@ -66,7 +66,7 @@
             ".Select-menu-outer .Select-option"
         );
         reasonOption.forEach(function (option) {
-            if (option.ariaLabel === reason) {
+            if (option.getAttribute("aria-label") === reason) {
                 option.dispatchEvent(mouseDown);
             }
         });


### PR DESCRIPTION
## Done
Firefox does not support `ariaLabel` therefore I have changed to a way to get this value using the `getAttribute` method which is universally supported.

## QA
1. Copy this script over your installed one and go to the application review screen
2. Try the reject buttons still work as expected
3. Switch to Firefox and test that it works too

Fixes https://warthogs.atlassian.net/browse/WD-3819 