### PR TITLE
WD-3825 Replace Wrong timezone with Jumpy career

### DIFF
--- a/application-review.user.js
+++ b/application-review.user.js
@@ -140,8 +140,8 @@
       <button data-name="Illegible language" data-reason="Illegible language" class="rejection__button">
         Illegible language
       </button>
-      <button data-name="Wrong timezone" data-reason="Wrong timezone" class="rejection__button">
-        Wrong timezone
+      <button data-name="Jumpy career" data-reason="Jumpy career" class="rejection__button">
+        Jumpy career
       </button>
     </div>
     <style>


### PR DESCRIPTION
## Done
We received feedback on the weekly hiring meeting that we would like to switch the quick reject button from Wrong timezone to the Jumpy career.

## QA
1. Override your local install of the plugin with this script
2. Reload the application view
3. Find someone with a Jumpy career and reject using the reject buttons
4. Check that candidate is rejected for the correct reason.

Fixes https://warthogs.atlassian.net/browse/WD-3825