### PR TITLE
Use regex for each question

### DIFF
--- a/application-review-helper.user.js
+++ b/application-review-helper.user.js
@@ -69,23 +69,23 @@
                 if (questionText.startsWith("Describe")) {
                     question.classList.add(textReview(answer));
                 } else {
-                    switch (questionText) {
-                        case "Are you due to graduate soon, or have you graduated from university in the past two years?":
+                    switch (true) {
+                        case /Are you due to graduate soon, or have you graduated from university in the past two years\?/.test(questionText):
                             question.classList.add("elephant");
                             break;
-                        case "What time zone are you in?":
+                        case /What time zone are you in\?/.test(questionText):
                             question.classList.add("elephant");
                             break;
-                        case "What is your degree result? i.e. Upper second, 2.1, 85%, First class, GPA 3.8/4.0 (expected)":
+                        case /What is your degree result\?/.test(questionText):
                             question.classList.add(degreeReview(answer));
                             break;
-                        case "How did you do in maths, physics or computer science at high school?":
+                        case /How did you do in maths, physics or computer science at high school\?/.test(questionText):
                             question.classList.add(doReview(answer));
                             break;
-                        case "How did you do in your native language at high school?":
+                        case /How did you do in your native language at high school\?/.test(questionText):
                             question.classList.add(doReview(answer));
                             break;
-                        case "We expect all colleagues to meet in person twice a year, at internal company events. We try to pick interesting and new locations, so this requires international travel for a total of 2-4 weeks per year depending on your responsibilities. Are you willing and able to commit to this?":
+                        case /We expect all colleagues to meet in person twice a year.* Are you willing and able to commit to this\?/.test(questionText):
                             question.classList.add(yesReview(answer));
                             break;
                         default:


### PR DESCRIPTION
The main motivation is to have some additional travel requirements on top of "We expect all colleagues to meet in person twice a year" since some positions requires more travels to visit customers, etc.