### PR TITLE
add script for talent interview field reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Here is the list of the available Userscripts:
 -   [Greenhouse Application Review](https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/application-review.user.js): Add quick rejection buttons to the application review page, to perform rejection with one button click
 -   [Greenhouse written interviews in a new tab](https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/written-interview-in-new-tab.user.js): Open written interviews in a new tab instead of downloading "File1.pdf" files
 -   [Greenhouse Application Review Helper](https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/application-review-helper.user.js): Adds additional icons to suggest the quality of the answer for custom application questions
+-   [Talent Interview Field Reminder](https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/talent-interview-field-reminder.user.js): Create a reminder to update application custom fields after moving candidates to the Talent Interview stage
 
 ## Getting started
 
@@ -40,6 +41,7 @@ Once the browser extension is installed, for each script the you wish to install
 -   Greenhouse application review: https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/application-review.user.js
 -   Greenhouse written interviews in a new tab: https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/written-interview-in-new-tab.user.js
 -   Greenhouse Application Review Helper: https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/application-review-helper.user.js
+-   Talent Interview Field Reminder: https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/talent-interview-field-reminder.user.js
 
 ## Receiving updates
 
@@ -82,3 +84,9 @@ When this is enabled you will see this addition element in the toolbar:
 Open written interviews in a new tab instead of downloading "File1.pdf" files.
 
 Once the Userscript is installed, you may need to authorize popups for the first time.
+
+## Greenhouse talent interview field reminder
+
+Creates an alert when a candidate is moved into the Talent Interview stage.
+
+The alert will remind HLs to update the 'HL - Proposed level' and 'HL - Years of relevant experience' fields.

--- a/talent-interview-field-reminder.user.js
+++ b/talent-interview-field-reminder.user.js
@@ -1,0 +1,32 @@
+// ==UserScript==
+// @name         Talent Interview Field Reminder
+// @namespace    https://canonical.com/
+// @version      1.0
+// @author       Ulas Coskun
+// @description  Create a reminder to update application custom fields after moving candidates to the Talent Interview stage
+// @homepage     https://github.com/canonical/greenhouse-browser-scripts
+// @homepageURL  https://github.com/canonical/greenhouse-browser-scripts
+// @supportURL   https://github.com/canonical/greenhouse-browser-scripts/issues
+// @updateURL    https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/talent-interview-field-reminder.user.js
+// @downloadURL  https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/talent-interview-field-reminder.user.js
+// @icon         https://icons.duckduckgo.com/ip3/greenhouse.io.ico
+// @grant        none
+
+// @match        https://canonical.greenhouse.io/people/**?application_id=**
+// ==/UserScript==
+
+(function() {
+    'use strict';
+
+    /* Get the 'Talent Interview' button under the 'Move stage' popup field.
+    The class for the button of the stage where the candidate is currently in is different from the class of the other buttons.
+    Therefore this const will be undefined if the candidate is already in the Talent Interview stage when the page loads.*/
+    const talentInterviewButton = Array.from(document
+                               .querySelectorAll("div[class='small-button stage-option ']"))
+                               .filter(element => element.textContent.includes("Talent Interview"))[0];
+
+    // Add eventListener to create an alert when the 'Talent Interview' button is clicked and the candidate isn't already in the Talent Interview stage.
+    talentInterviewButton.addEventListener('click', () => {
+            alert("Please enter the 'HL - Proposed level' and 'HL - Years of relevant experience' information into the Application Custom Fields under the Application tab.")
+        })
+})();


### PR DESCRIPTION
Add new script to create an alert when a candidate is moved into the Talent Interview stage. The alert will remind HLs to update the 'HL - Proposed level' and 'HL - Years of relevant experience' fields.