### PR TITLE
Rejection emails sent from no-reply

### DIFF
--- a/application-review.user.js
+++ b/application-review.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Greenhouse Application Review
 // @namespace    https://canonical.com/
-// @version      1.1.0
+// @version      1.1.1
 // @author       Canonical's workplace engineering team
 // @description  Add shortcut buttons to application review page
 // @homepage     https://github.com/canonical/greenhouse-browser-scripts
@@ -19,6 +19,7 @@
 
     const rejectBtnEl = document.querySelector("*[data-provides='reject']");
     const actionsBarEl = rejectBtnEl.parentNode;
+    let submitTimeout = 500;
 
     const keyDown = new KeyboardEvent("keydown", {
         bubbles: true,
@@ -70,7 +71,17 @@
                 option.dispatchEvent(mouseDown);
             }
         });
+        let templateInput;
+        let fromInput;
         let subjectInput;
+        const dropdownContainers = rejectModal.querySelectorAll(
+            '#reject-modal .sl-dropdown-container'
+        );
+        dropdownContainers.forEach((input) => {
+            if (input.previousElementSibling?.innerText === "From") {
+                fromInput = input;
+            }
+        });
         const inputs = rejectModal.querySelectorAll(
             '#reject-modal input[type="text"]'
         );
@@ -82,14 +93,15 @@
         const rejectChecker = setInterval(() => {
             if (subjectInput.value !== "") {
                 clearInterval(rejectChecker);
+                setFromToNoReply(fromInput)
                 rejectButton.click();
                 setEnabled();
                 setTimeout(
                     () => rejectModal.classList.remove("hide-modal"),
-                    500
+                    1000
                 );
             }
-        }, 500);
+        }, 1000);
     }
 
     // State utilities
@@ -124,6 +136,21 @@
     }
 
     // Common functions
+    function setFromToNoReply(fromInput) {
+        if (!fromInput.innerText.startsWith("no-reply")) {
+            fromInput.querySelector('.sl-dropdown__control').dispatchEvent(mouseDown);
+            const replyOption = fromInput.querySelectorAll(
+                ".sl-dropdown__option"
+            );
+
+            replyOption.forEach(function (option) {
+                if (option.innerText.startsWith("no-reply")) {
+                    option.click();
+                    option.dispatchEvent(mouseDown);
+                }
+            });
+        }
+    }
 
     function addUI(container) {
         container.insertAdjacentHTML(


### PR DESCRIPTION
## Done

Greenhouse tries to remember your email settings from previous emails but the PR sets the "From" value of the quick reject to no-reply every time. 

## QA

1. Install Tampermonkey as the README suggests
2. Copy this script to a script or override the current install Greenhouse Application Review  
3. Go to a test open application in the application review screen
4. Click the normal Reject button to bring up the modal 
5. Set the from email to your email
6. Close the modal
7. Middle-click on the name of the candidate to open a new tab
8. Click one of the quick reject reasons
9. Go to the newly opened tab and refresh
10. Go to the activity tab and see the email sent to the candidate was from no-reply (not your email)