### PR TITLE
Incorporate Ant's changes for Application Review Helper

### DIFF
--- a/application-review-helper.user.js
+++ b/application-review-helper.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Greenhouse Application Review Helper
 // @namespace    https://canonical.com/
-// @version      0.1.15
+// @version      0.1.16
 // @description  Add's hints to application custom question answers
 // @author       Anthony Dillon
 // @icon         https://icons.duckduckgo.com/ip3/greenhouse.io.ico

--- a/application-review-helper.user.js
+++ b/application-review-helper.user.js
@@ -68,7 +68,7 @@
                 clearClass(question);
                 if (questionText.startsWith("Describe")) {
                     question.classList.add(textReview(answer));
-                } else if (questionText.startsWith("What was your bachelor's university degree result")) {
+                } else if (questionText.includes("degree result")) {
                     question.classList.add(degreeReview(answer)); 
                 } else {
                     switch (true) {
@@ -147,8 +147,8 @@
             return "pecise";
         }
         if (answer.includes("GPA")) {
-            var removeColon = answer.replace(":", "");
-            var splitBySpace = removeColon.split(" ");
+            var cleanUp = answer.replace(":", "");
+            var splitBySpace = cleanUp.split(" ");
             var index = splitBySpace.indexOf("GPA");
             var score = splitBySpace[index + 1];
             var GPACheckResult = GPACheck(score);
@@ -284,42 +284,12 @@
         element.classList.remove("pebble");
     }
 
-    // debounce function to limit how often run() is called
-    let debounceTimer;
-    function debounceRun() {
-        clearTimeout(debounceTimer);
-        debounceTimer = setTimeout(run, 300);
-    }
-
-    // initial run to handle questions visible on page load
-    run();
-
     // mutation observer to watch for changes in the review container
-    const observer = new MutationObserver((mutations) => {
-        let shouldRun = false;
-        for (let mutation of mutations) {
-            if (mutation.type === 'childList' || mutation.type === 'subtree') {
-                shouldRun = true;
-                break;
-            }
-        }
-        if (shouldRun) {
-            debounceRun();
-        }
+    const config = { attributes: false, childList: true, subtree: true };
+    const observer = new MutationObserver(function () {
+        setTimeout(run, 0);
     });
+    observer.observe(reviewContainer, config);
 
-    // function to start observing the review container
-    function startObserver() {
-        const reviewContainer = document.querySelector('div[data-provides="app-review"]');
-        if (reviewContainer) {
-            // start mutation observer
-            observer.observe(reviewContainer, { childList: true, subtree: true });
-        } else {
-            // review container not found, try again in 1 second
-            setTimeout(startObserver, 1000);
-        }
-    }
-
-    // start the observer
-    startObserver();
+    run();
 })();

--- a/application-review-helper.user.js
+++ b/application-review-helper.user.js
@@ -5,8 +5,8 @@
 // @description  Add's hints to application custom question answers
 // @author       Anthony Dillon
 // @icon         https://icons.duckduckgo.com/ip3/greenhouse.io.ico
-// @updateURL    https://raw.githubusercontent.com/anthonydillon/greenhouse-app-review-script/main/application-review-helper.user.js
-// @downloadURL  https://raw.githubusercontent.com/anthonydillon/greenhouse-app-review-script/main/application-review-helper.user.js
+// @updateURL    https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/application-review-helper.user.js
+// @downloadURL  https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/application-review-helper.user.js
 // @grant        none
 // @match        https://canonical.greenhouse.io/applications/review/*
 // ==/UserScript==


### PR DESCRIPTION
## Rationale
I recently made changes to the Application Review Helper script to fix icons loading forever and add new questions that were added to the questions set (#66). Ant also recently made changes to fix the same problems (#65). This PR is to coalesce the two fixes.

## Done
- The main changes are to use the simplified MutationObserver implementation from Ant's fix, as well as some variable name changes.

## QA
- Copy the Application Review Helper script code and paste it into Tampermonkey as a new script
- Change the name to TEST or something of this sort so that it will not overwrite the existing one from the github link (if you have it installed already)
- Navigate to App Review page and ensure that icons show up as expected
- Click the "See all" link and ensure that icons under the fold load as expected