### PR TITLE
Feat: Add browserscript to paint header in duplicate tag color and automatically open duplicate profile in new tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Here is the list of the available Userscripts:
 -   [Greenhouse Application Review](https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/application-review.user.js): Add quick rejection buttons to the application review page, to perform rejection with one button click
 -   [Greenhouse written interviews in a new tab](https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/written-interview-in-new-tab.user.js): Open written interviews in a new tab instead of downloading "File1.pdf" files
 -   [Greenhouse Application Review Helper](https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/application-review-helper.user.js): Adds additional icons to suggest the quality of the answer for custom application questions
+-   [Greenhouse Duplicate Check Helper](https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/duplicate-check.user.js): If a candidate duplicate tag is detected, the script colors the entire header, so that it is harder to overlook. Also, it opens the duplicate candidate in a new tab so that you can start checking quicker.
 -   [Talent Interview Field Reminder](https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/talent-interview-field-reminder.user.js): Create a reminder to update application custom fields after moving candidates to the Talent Interview stage
 -   [To-do expander](https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/todo-expander.user.js): Provides a "Reveal all" button to the bulk action set to expand the todo per candidate row
 
@@ -42,6 +43,7 @@ Once the browser extension is installed, for each script the you wish to install
 -   Greenhouse application review: https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/application-review.user.js
 -   Greenhouse written interviews in a new tab: https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/written-interview-in-new-tab.user.js
 -   Greenhouse Application Review Helper: https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/application-review-helper.user.js
+-   Greenhouse Duplicate Check Helper: https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/duplicate-check.user.js
 -   Talent Interview Field Reminder: https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/talent-interview-field-reminder.user.js
 
 ## Receiving updates

--- a/__tests__/duplicate-check.test.js
+++ b/__tests__/duplicate-check.test.js
@@ -1,0 +1,51 @@
+import { JSDOM } from "jsdom";
+
+describe("Written interview in new tab test", () => {
+    let appReview;
+    let header;
+
+    beforeAll(() => {
+        const dom = new JSDOM(
+            `
+            <!DOCTYPE html>
+            <html>
+            <head></head>
+              <body>
+                <div data-provides="app-review">
+                  <header>
+                    <div data-birch="Grid">
+                      <a href="/people/xxxxxxxxx?application_id=yyyyyyyyy" target="_blank">First Last</a>
+                    </div>
+                  </header>
+                  <div>
+                    <!-- roughly GHs structure for the duplicate tag -->
+                    <span class="chip" title="Potential duplicate">
+                      <span class="chip">Potential duplicate</span>
+                      <span></span>
+                    </span>
+                  </div>
+                 </div>
+                <script>
+                ${require("fs").readFileSync("duplicate-check.user.js", "utf8")}
+                </script>
+              </body>
+            </html>
+            `,
+            {
+                runScripts: "dangerously",
+                resources: "usable",
+            }
+        );
+
+        appReview = dom.window.document.querySelector(
+            'div[data-provides="app-review"]'
+        );
+        header = appReview.querySelector("header");
+    });
+
+    it("detects the tag and paints the header", () => {
+        expect(header.style.backgroundColor).toBe("rgb(247, 200, 176)");
+        // it seems like I cannot mock a tampermonkey internal function so I cannot test the
+        // open in tab call
+    });
+});

--- a/duplicate-check.user.js
+++ b/duplicate-check.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         Open Candidate Profile in new Tab if Duplicate Batch is detected
+// @name         Open Candidate Profile in new Tab if Duplicate Badge is detected
 // @namespace    https://canonical.com/
 // @version      2024-11-25
 // @author       Thorsten Merten <thorsten.merten@canonical.com>

--- a/duplicate-check.user.js
+++ b/duplicate-check.user.js
@@ -1,0 +1,96 @@
+// ==UserScript==
+// @name         Open Candidate Profile in new Tab if Duplicate Batch is detected
+// @namespace    https://canonical.com/
+// @version      2024-11-25
+// @author       Thorsten Merten <thorsten.merten@canonical.com>
+// @description  This script will color the entire header and open a new tab automatically if the candiate duplicate tag is detected. Saves time and reminds you to get merging.
+// @homepage     https://github.com/canonical/greenhouse-browser-scripts
+// @homepageURL  https://github.com/canonical/greenhouse-browser-scripts
+// @icon         https://icons.duckduckgo.com/ip3/greenhouse.io.ico
+// @homepage     https://github.com/canonical/greenhouse-browser-scripts
+// @match        https://canonical.greenhouse.io/applications/review/app_review*
+// @updateURL    https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/duplicate-check.user.js
+// @downloadURL  https://raw.githubusercontent.com/canonical/greenhouse-browser-scripts/main/duplicate-check.user.js
+// @supportURL   https://github.com/canonical/greenhouse-browser-scripts/issues
+// @grant        GM_openInTab
+// ==/UserScript==
+
+(function () {
+    "use strict";
+
+    // do all operations in this container
+    const reviewContainer = document.querySelector(
+        'div[data-provides="app-review"]'
+    );
+    const header = reviewContainer.querySelector(
+        'header'
+    );
+    const candidateLink = header.querySelector(
+        'a[target="_blank"][href*="people"]'
+    );
+
+    function logMutations(mutationList) {
+        /* convenience helper to log all possible mutations for a mutation list.
+         * Takes a MutationObserver.mutationList and tries to log what changed
+         * on the observed item
+         */
+        mutationList.forEach(mutation => {
+            if (mutation.type === "childList") {
+                console.log("A child node has been added or removed.");
+                console.log(mutation)
+            } else if (mutation.type === "characterData") {
+                console.log("Character data change detected.");
+                console.log(mutation)
+            } else if (mutation.type === "subtree") {
+                console.log("Subtree change detected.");
+                console.log(mutation)
+            } else if (mutation.type === "attributes") {
+                console.log(`The ${mutation.attributeName} attribute was modified.`);
+            }
+        });
+    }
+
+    function checkDuplicateAndOpenInTab() {
+        /* do the actual checking and logging */
+        if (reviewContainer && candidateLink) {
+
+            let duplicateTag = reviewContainer.querySelector('span[title="Potential duplicate"]');
+
+            if (duplicateTag) {
+                // match greenhouse tag color
+                header.style.backgroundColor = '#f7c8b0';
+
+                setTimeout(() => {
+                    GM_openInTab(candidateLink.href);
+                    //alert('in timeout and if duplicate tag: ' + candidateLink.href);
+                }, 250);
+            } else {
+                header.style.backgroundColor = null;
+            }
+        }
+    }
+
+    // make sure to run before observer is registered to prevent double trigger
+    checkDuplicateAndOpenInTab();
+
+    // for page load (Do not use DOMSubtreeModified event as its obsolete and about to be deprecated)
+    const observer = new MutationObserver(mutationList => {
+        console.log('mutation observer triggered')
+        // logMutations(mutationList);
+        mutationList.forEach(mutation => {
+            console.log(mutation)
+            if (mutation.type === "childList" &&
+                mutation.addedNodes.length > 0 &&
+                mutation.removedNodes.length === 0)
+            {
+                console.log('found the mutation that adds the nodes')
+                // trigger the check only if a node was added (avoids duplicate tab opening)
+                checkDuplicateAndOpenInTab();
+            }
+        });
+    });
+
+    // watch the state of a particular element for updating instead of the whole container
+    observer.observe(header, { attributes: false, characterData: false, childList: true, subtree: true }); // availale props: attributes, characterData, childList, subtree
+
+})();

--- a/duplicate-check.user.js
+++ b/duplicate-check.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Open Candidate Profile in new Tab if Duplicate Badge is detected
 // @namespace    https://canonical.com/
-// @version      2024-11-25
+// @version      0.1.0
 // @author       Thorsten Merten <thorsten.merten@canonical.com>
 // @description  This script will color the entire header and open a new tab automatically if the candiate duplicate tag is detected. Saves time and reminds you to get merging.
 // @homepage     https://github.com/canonical/greenhouse-browser-scripts


### PR DESCRIPTION
This script checks the dom on page load and on "candidate change" for a duplicate tag. If a tag is found it paints the entire header in duplicate tag color (as the tag can easily be overlooked)  and opens the candidate profile in a new tab, so that the profile loads in the background and duplicate checking requires one less click and can be performed more quickly.

Also add a simple test which checks if the header is correctly painted in duplicate tag color if a tag is found in the dom. 

_Unfortunately, I did not find a simple way to test the dynamic behavior and mock `GH_openInTab` from tampermonkey. However, the script is not destructive and does not change any data._


![image](https://github.com/user-attachments/assets/fdb0694e-27d6-4e69-a905-ee0aee404e59)
