### PR TITLE
Update Google Meet auto-select script to work with new Greenhouse UI as well

### DIFF
--- a/google-meet-auto-select.user.js
+++ b/google-meet-auto-select.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Greenhouse Google Meet Auto-select
 // @namespace    https://canonical.com/
-// @version      0.1.0
+// @version      1.1.0
 // @author       Nathan Clairmonte <nathan.clairmonte@canonical.com>
 // @description  Automatically selects "Google Meet" option for video conferencing on Greenhouse manual scheduling page.
 // @homepage     https://github.com/canonical/greenhouse-browser-scripts

--- a/google-meet-auto-select.user.js
+++ b/google-meet-auto-select.user.js
@@ -32,8 +32,8 @@
 
     console.log("[GH GMeet Auto-select] Script execution started.", true);
 
-    const MAX_RETRIES = 23;
-    const RETRY_DELAY = 500;
+    const MAX_RETRIES = 100;
+    const RETRY_DELAY = 50;
     let hasSuccessfullySelectedMeet = false;
     let workflowActionInProgress = false;
 


### PR DESCRIPTION
## Rationale

Greenhouse have two UIs for their manual scheduling page. The previous version of this script only worked for the old UI, and so users had to take an extra step sometimes to alter the URL to access the old UI for manual scheduling in order to take advantage of this script. This update facilitates the auto-select functionality on the new UI as well.


## Done

- reduce retry delay
- update script to work with new UI as well
- bump version


## QA

- Go to Tampermonkey dashboard
- Select "Installed Userscripts" and turn off any previous versions of this script to avoid any clashes with the new version when testing
- Select the plus sign on the left of the tabs
  
![image](https://github.com/user-attachments/assets/a45c784c-b3dc-4c12-b62d-283b42033f6d)

- Copy the script from the branch and paste it in
- Ensure script still works on old UI:
  - Navigate to the manual scheduling page (old UI) for test candidate: https://canonical.greenhouse.io/interviews/scheduler?application_id=345444888&interview_kit_id=30727371&landing_page=manualScheduling
  - Select a timeslot on the calendar view
  - Click "Schedule and Continue" in the bottom right-hand corner
  - On the next page, ensure that the "Google Meet" option is automatically selected as expected
- Ensure script works on new UI:
  - Navigate to the manual scheduling page (new UI) for test candidate: https://canonical.greenhouse.io/interviews/scheduler/v2?application_id=345444888&interview_kit_id=30727371&landing_page=manualScheduling
  - Select a timeslot on the calendar view
  - Click "Continue" in the top right-hand corner
  - On the next page, ensure that the "Google Meet" option is automatically selected as expected
- Turn off/delete the script you just added so it doesn't clash with any future versions


## Issue / Card
[TSP-850](https://warthogs.atlassian.net/browse/TSP-850)



[TSP-850]: https://warthogs.atlassian.net/browse/TSP-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ